### PR TITLE
'-v' option does not accept any argument

### DIFF
--- a/utils/jenkins/system_tests.sh
+++ b/utils/jenkins/system_tests.sh
@@ -136,7 +136,7 @@ GlobalVariables() {
 }
 
 GetoptsVariables() {
-  while getopts ":w:j:i:t:o:a:A:m:U:r:b:V:l:LdkKe:v:h" opt; do
+  while getopts ":w:j:i:t:o:a:A:m:U:r:b:V:l:LdkKe:vh" opt; do
     case $opt in
       w)
         WORKSPACE="${OPTARG}"


### PR DESCRIPTION
From help:
...
 -j (name)   - Name of this job. Determines ISO name, Task name and used by tests.
               Uses Jenkins' JOB_NAME if not set
 -v          - Do not use virtual environment
...
